### PR TITLE
update image preview link creation when navigation next/prev

### DIFF
--- a/sections/Warline/Popup.tsx
+++ b/sections/Warline/Popup.tsx
@@ -83,7 +83,7 @@ const Popup = ({
       originalSrc,
       animationSrc,
       isAnimation,
-    } = getUrls(eventData.Tokenid, eventData.ImageType, randomSrc as string);
+    } = getUrls(data.Tokenid, data.ImageType, randomSrc as string);
 
     const logoSrc = isAnimation ? animationSrc : previewSrc;
 


### PR DESCRIPTION
closes https://github.com/museum-of-war/web/issues/20

When user click next/prev button the link for preview is generated from `eventData`, i.e it does not use actual event data that is [updated on event change](https://github.com/museum-of-war/web/blob/main/sections/Warline/Popup.tsx#L42)